### PR TITLE
[RFR] Add the full-text filter (q)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,18 @@ Content-Type: application/json
   { id: 3, author_id: 1, title: 'Sense and Sensibility' },
   { id: 2, author_id: 1, title: 'Pride and Prejudice' }
 ]
+
+// the special "q" filter makes a full-text search on all text fields
+GET /books?filter={q:'and'}
+
+HTTP 1.1 200 OK
+Content-Range: items 0-2/3
+Content-Type: application/json
+[
+  { id: 1, author_id: 0, title: 'War and Peace' },
+  { id: 2, author_id: 1, title: 'Pride and Prejudice' },
+  { id: 3, author_id: 1, title: 'Sense and Sensibility' }
+]
 ```
 
 * `POST /foo` returns a status 201 with a `Location` header for the newly created resource, and the new resource in the body.

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -7,6 +7,14 @@ function filterItems(items, filter) {
     if (filter instanceof Object) {
         return items.filter(item => {
             for (let key in filter) {
+                if (key === 'q') {
+                    // full-text filter
+                    for (let itemKey in item) {
+                        if (item[itemKey].indexOf && item[itemKey].indexOf(filter.q) !== -1) return true;
+                    }
+                    return false;
+                }
+                // simple filter
                 if (item[key] != filter[key]) return false;
             }
             return true;

--- a/test/src/Collection-spec.js
+++ b/test/src/Collection-spec.js
@@ -124,6 +124,18 @@
                     expect(collection.getAll({filter: { name: 'b'} })).toEqual(expected)
                 });
 
+                it('should filter by the special q full-text filter', function() {
+                    var collection = new Collection([
+                        { a: 'hello', b: 'world' },
+                        { a: 'helloworld', b: 'bunny'},
+                        { a: 'foo', b: 'bar'},
+                        { a: '', b: '' },
+                        {}
+                    ]);
+                    expect(collection.getAll({filter: { q: 'hello'} })).toEqual([ { id: 0, a: 'hello', b: 'world' }, { id: 1, a: 'helloworld', b: 'bunny'} ])
+                    expect(collection.getAll({filter: { q: 'bar'} })).toEqual([{ id: 2, a: 'foo', b: 'bar'}])
+                })
+
                 it('should not affect further requests', function() {
                     var collection = new Collection([{name: 'c'}, {name: 'a'}, {name: 'b'}]);
                     function filter(item) {


### PR DESCRIPTION
```
// the special "q" filter makes a full-text search on all text fields
GET /books?filter={q:'and'}

HTTP 1.1 200 OK
Content-Range: items 0-2/3
Content-Type: application/json
[
  { id: 1, author_id: 0, title: 'War and Peace' },
  { id: 2, author_id: 1, title: 'Pride and Prejudice' },
  { id: 3, author_id: 1, title: 'Sense and Sensibility' }
]
```