### PR TITLE
[RFR] Add embed support

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,12 +221,12 @@ restServer.batchUrl('/batch');
 // you can create more than one fake server to listen to several domains
 var restServer2 = new FakeRest.Server('http://my.other.domain');
 // Set data collection by collection - allows to customize the identifier name
-var authorsCollection = new RestServer.Collection([], '_id');
+var authorsCollection = new FakeRest.Collection([], '_id');
 authorsCollection.addOne({ first_name: 'Leo', last_name: 'Tolstoi' }); // { _id: 0, first_name: 'Leo', last_name: 'Tolstoi' }
 authorsCollection.addOne({ first_name: 'Jane', last_name: 'Austen' }); // { _id: 1, first_name: 'Jane', last_name: 'Austen' }
 // collections have autoincremented identifier but accept identifiers already set
 authorsCollection.addOne({ _id: 3, first_name: 'Marcel', last_name: 'Proust' }); // { _id: 3, first_name: 'Marcel', last_name: 'Proust' }
-restServer2.addCollection('books', authorsCollection);
+restServer2.addCollection('authors', authorsCollection);
 // collections are mutable
 authorsCollection.updateOne(1, { last_name: 'Doe' }); // { _id: 1, first_name: 'Jane', last_name: 'Doe' }
 authorsCollection.removeOne(3); // { _id: 3, first_name: 'Marcel', last_name: 'Proust' }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "karma-spec-reporter": "0.0.16",
     "karma-traceur-preprocessor": "^0.4.0",
     "sinon": "^1.14.1",
+    "string.prototype.endswith": "^0.2.0",
     "webpack": "^1.7.1"
   }
 }

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -143,9 +143,17 @@ export default class Collection {
         return (item) => {
             const otherCollection = this.server.collections[resourceName];
             if (!otherCollection) throw new Error(`Can't embed a non-existing collection ${resourceName}`);
-            item[resourceName] = otherCollection.getAll({
-                filter: i => i[referenceName] == item[this.identifierName]
-            });
+            if (Array.isArray(item[resourceName])) {
+                // the many to one relationship is carried by an array of ids, e.g. { posts: [1, 2] } in authors
+                item[resourceName] = otherCollection.getAll({
+                    filter: i => item[resourceName].indexOf(i[otherCollection.identifierName]) !== -1
+                });
+            } else {
+                // the many to one relationship is carried by references in the related collection, e.g. { author_id: 1 } in posts
+                item[resourceName] = otherCollection.getAll({
+                    filter: i => i[referenceName] == item[this.identifierName]
+                });
+            }
             return item;
         };
     }

--- a/src/Collection.js
+++ b/src/Collection.js
@@ -139,7 +139,7 @@ export default class Collection {
      */
     _oneToManyEmbedder(resourceName) {
         const singularResourceName = this.name.slice(0,-1);
-        const referenceName = singularResourceName + 'Id';
+        const referenceName = singularResourceName + '_id';
         return (item) => {
             const otherCollection = this.server.collections[resourceName];
             if (!otherCollection) throw new Error(`Can't embed a non-existing collection ${resourceName}`);
@@ -161,7 +161,7 @@ export default class Collection {
      */
     _manyToOneEmbedder(resourceName) {
         const pluralResourceName = resourceName + 's';
-        const referenceName = resourceName + 'Id';
+        const referenceName = resourceName + '_id';
         return (item) => {
             const otherCollection = this.server.collections[pluralResourceName];
             if (!otherCollection) throw new Error(`Can't embed a non-existing collection ${resourceName}`);

--- a/src/Server.js
+++ b/src/Server.js
@@ -37,7 +37,7 @@ export default class Server {
      */
     init(data) {
         for (let name in data) {
-            this.addCollection(name, new Collection(data[name]));
+            this.addCollection(name, new Collection(data[name], 'id'));
         }
     }
 
@@ -51,6 +51,8 @@ export default class Server {
 
     addCollection(name, collection) {
         this.collections[name] = collection;
+        collection.setServer(this);
+        collection.setName(name);
     }
 
     getCollection(name) {
@@ -85,8 +87,8 @@ export default class Server {
         return this.collections[name].getAll(params);
     }
 
-    getOne(name, identifier) {
-        return this.collections[name].getOne(identifier);
+    getOne(name, identifier, params) {
+        return this.collections[name].getOne(identifier, params);
     }
 
     addOne(name, item) {
@@ -247,8 +249,9 @@ export default class Server {
             } else {
                 let id = matches[3];
                 if (request.method == 'GET') {
+                    let params = request.params;
                     try {
-                        let item = this.getOne(name, id);
+                        let item = this.getOne(name, id, params);
                         return this.respond(item, null, request);
                     } catch (error) {
                         return request.respond(404);

--- a/test/src/Collection-spec.js
+++ b/test/src/Collection-spec.js
@@ -236,7 +236,7 @@
             describe('embed query', function() {
                 it('should throw an error when trying to embed a non-existing collection', function() {
                     var foos = new Collection([
-                        { name: 'John', barId: 123 }
+                        { name: 'John', bar_id: 123 }
                     ]);
                     var server = new Server();
                     server.addCollection('foos', foos);
@@ -245,20 +245,20 @@
 
                 it('should return the original object for missing embed one', function() {
                     var foos = new Collection([
-                        { name: 'John', barId: 123 }
+                        { name: 'John', bar_id: 123 }
                     ]);
                     var bars = new Collection([]);
                     var server = new Server();
                     server.addCollection('foos', foos);
                     server.addCollection('bars', bars);
-                    var expected = [{ id: 0, name: 'John', barId: 123 }];
+                    var expected = [{ id: 0, name: 'John', bar_id: 123 }];
                     expect(foos.getAll({ embed: ['bar'] })).toEqual(expected);
                 });
 
                 it('should return the object with the reference object for embed one', function() {
                     var foos = new Collection([
-                        { name: 'John', barId: 123 },
-                        { name: 'Jane', barId: 456 }
+                        { name: 'John', bar_id: 123 },
+                        { name: 'Jane', bar_id: 456 }
                     ]);
                     var bars = new Collection([
                         { id: 1, bar: 'nobody wants me' },
@@ -269,15 +269,15 @@
                     server.addCollection('foos', foos);
                     server.addCollection('bars', bars);
                     var expected = [
-                        { id: 0, name: 'John', barId: 123, bar: { id: 123, bar: 'baz' } },
-                        { id: 1, name: 'Jane', barId: 456, bar: { id: 456, bar: 'bazz' } }
+                        { id: 0, name: 'John', bar_id: 123, bar: { id: 123, bar: 'baz' } },
+                        { id: 1, name: 'Jane', bar_id: 456, bar: { id: 456, bar: 'bazz' } }
                     ];
                     expect(foos.getAll({ embed: ['bar'] })).toEqual(expected);
                 });
 
                 it('should throw an error when trying to embed many a non-existing collection', function() {
                     var foos = new Collection([
-                        { name: 'John', barId: 123 }
+                        { name: 'John', bar_id: 123 }
                     ]);
                     var server = new Server();
                     server.addCollection('foos', foos);
@@ -286,7 +286,7 @@
 
                 it('should return the object with an empty array for missing embed many', function() {
                     var foos = new Collection([
-                        { name: 'John', barId: 123 }
+                        { name: 'John', bar_id: 123 }
                     ]);
                     var bars = new Collection([
                         { id: 1, bar: 'nobody wants me' }
@@ -300,9 +300,9 @@
 
                 it('should return the object with an array of references for embed many', function() {
                     var foos = new Collection([
-                        { id: 1, name: 'John', barId: 123 },
-                        { id: 2, name: 'Jane', barId: 456 },
-                        { id: 3, name: 'Jules', barId: 456 }
+                        { id: 1, name: 'John', bar_id: 123 },
+                        { id: 2, name: 'Jane', bar_id: 456 },
+                        { id: 3, name: 'Jules', bar_id: 456 }
                     ]);
                     var bars = new Collection([
                         { id: 1, bar: 'nobody wants me' },
@@ -315,11 +315,11 @@
                     var expected = [
                         { id: 1, bar: 'nobody wants me', foos: [] },
                         { id: 123, bar: 'baz', foos: [
-                            { id: 1, name: 'John', barId: 123 }
+                            { id: 1, name: 'John', bar_id: 123 }
                         ] },
                         { id: 456, bar: 'bazz', foos: [
-                            { id: 2, name: 'Jane', barId: 456 },
-                            { id: 3, name: 'Jules', barId: 456 }
+                            { id: 2, name: 'Jane', bar_id: 456 },
+                            { id: 3, name: 'Jules', bar_id: 456 }
                         ] }
                     ];
                     expect(bars.getAll({ embed: ['foos'] })).toEqual(expected);
@@ -327,13 +327,13 @@
 
                 it('should allow multiple embeds', function() {
                     var books = new Collection([
-                        { id: 1, title: 'Pride and Prejudice', authorId: 1 },
-                        { id: 2, title: 'Sense and Sensibility', authorId: 1 },
-                        { id: 3, title: 'War and Preace', authorId: 2 }
+                        { id: 1, title: 'Pride and Prejudice', author_id: 1 },
+                        { id: 2, title: 'Sense and Sensibility', author_id: 1 },
+                        { id: 3, title: 'War and Preace', author_id: 2 }
                     ]);
                     var authors = new Collection([
-                        { id: 1, firstName: 'Jane', lastName: 'Austen', countryId: 1 },
-                        { id: 2, firstName: 'Leo', lastName: 'Tosltoi', countryId: 2 }
+                        { id: 1, firstName: 'Jane', lastName: 'Austen', country_id: 1 },
+                        { id: 2, firstName: 'Leo', lastName: 'Tosltoi', country_id: 2 }
                     ]);
                     var countries = new Collection([
                         { id: 1, name: 'England' },
@@ -344,8 +344,8 @@
                     server.addCollection('authors', authors);
                     server.addCollection('countrys', countries); // nevermind the plural
                     var expected = [
-                        { id: 1, firstName: 'Jane', lastName: 'Austen', countryId: 1, books: [{ id: 1, title: 'Pride and Prejudice', authorId: 1 }, { id: 2, title: 'Sense and Sensibility', authorId: 1 },], country: { id: 1, name: 'England' } },
-                        { id: 2, firstName: 'Leo', lastName: 'Tosltoi', countryId: 2, books: [{ id: 3, title: 'War and Preace', authorId: 2 }], country: { id: 2, name: 'Russia' } }
+                        { id: 1, firstName: 'Jane', lastName: 'Austen', country_id: 1, books: [{ id: 1, title: 'Pride and Prejudice', author_id: 1 }, { id: 2, title: 'Sense and Sensibility', author_id: 1 },], country: { id: 1, name: 'England' } },
+                        { id: 2, firstName: 'Leo', lastName: 'Tosltoi', country_id: 2, books: [{ id: 3, title: 'War and Preace', author_id: 2 }], country: { id: 2, name: 'Russia' } }
                     ];
                     expect(authors.getAll({embed: ['books', 'country']})).toEqual(expected);
                 });

--- a/test/src/Collection-spec.js
+++ b/test/src/Collection-spec.js
@@ -325,6 +325,33 @@
                     expect(bars.getAll({ embed: ['foos'] })).toEqual(expected);
                 });
 
+                it('should return the object with an array of references for embed many using inner array', function() {
+                    var foos = new Collection([
+                        { id: 1, name: 'John' },
+                        { id: 2, name: 'Jane' },
+                        { id: 3, name: 'Jules' }
+                    ]);
+                    var bars = new Collection([
+                        { id: 1, bar: 'nobody wants me' },
+                        { id: 123, bar: 'baz', foos: [1] },
+                        { id: 456, bar: 'bazz', foos: [2, 3] }
+                    ]);
+                    var server = new Server();
+                    server.addCollection('foos', foos);
+                    server.addCollection('bars', bars);
+                    var expected = [
+                        { id: 1, bar: 'nobody wants me', foos: [] },
+                        { id: 123, bar: 'baz', foos: [
+                            { id: 1, name: 'John' }
+                        ] },
+                        { id: 456, bar: 'bazz', foos: [
+                            { id: 2, name: 'Jane' },
+                            { id: 3, name: 'Jules' }
+                        ] }
+                    ];
+                    expect(bars.getAll({ embed: ['foos'] })).toEqual(expected);
+                });
+
                 it('should allow multiple embeds', function() {
                     var books = new Collection([
                         { id: 1, title: 'Pride and Prejudice', author_id: 1 },

--- a/test/src/Collection-spec.js
+++ b/test/src/Collection-spec.js
@@ -4,6 +4,7 @@
     'use strict';
 
     var Collection = FakeRest.Collection;
+    var Server = FakeRest.Server;
 
     describe('Collection', function() {
 
@@ -230,6 +231,125 @@
                     var expected  = [ {id: 0, name: 'a'}, {id: 1, name: 'b'}, {id: 2, name: 'c'} ];
                     expect(collection.getAll()).toEqual(expected)
                 });
+            });
+
+            describe('embed query', function() {
+                it('should throw an error when trying to embed a non-existing collection', function() {
+                    var foos = new Collection([
+                        { name: 'John', barId: 123 }
+                    ]);
+                    var server = new Server();
+                    server.addCollection('foos', foos);
+                    expect(function() { foos.getAll({ embed: ['bar'] }); }).toThrow(new Error('Can\'t embed a non-existing collection bar'));
+                })
+
+                it('should return the original object for missing embed one', function() {
+                    var foos = new Collection([
+                        { name: 'John', barId: 123 }
+                    ]);
+                    var bars = new Collection([]);
+                    var server = new Server();
+                    server.addCollection('foos', foos);
+                    server.addCollection('bars', bars);
+                    var expected = [{ id: 0, name: 'John', barId: 123 }];
+                    expect(foos.getAll({ embed: ['bar'] })).toEqual(expected);
+                });
+
+                it('should return the object with the reference object for embed one', function() {
+                    var foos = new Collection([
+                        { name: 'John', barId: 123 },
+                        { name: 'Jane', barId: 456 }
+                    ]);
+                    var bars = new Collection([
+                        { id: 1, bar: 'nobody wants me' },
+                        { id: 123, bar: 'baz' },
+                        { id: 456, bar: 'bazz' }
+                    ]);
+                    var server = new Server();
+                    server.addCollection('foos', foos);
+                    server.addCollection('bars', bars);
+                    var expected = [
+                        { id: 0, name: 'John', barId: 123, bar: { id: 123, bar: 'baz' } },
+                        { id: 1, name: 'Jane', barId: 456, bar: { id: 456, bar: 'bazz' } }
+                    ];
+                    expect(foos.getAll({ embed: ['bar'] })).toEqual(expected);
+                });
+
+                it('should throw an error when trying to embed many a non-existing collection', function() {
+                    var foos = new Collection([
+                        { name: 'John', barId: 123 }
+                    ]);
+                    var server = new Server();
+                    server.addCollection('foos', foos);
+                    expect(function() { foos.getAll({ embed: ['bars'] }); }).toThrow(new Error('Can\'t embed a non-existing collection bars'));
+                })
+
+                it('should return the object with an empty array for missing embed many', function() {
+                    var foos = new Collection([
+                        { name: 'John', barId: 123 }
+                    ]);
+                    var bars = new Collection([
+                        { id: 1, bar: 'nobody wants me' }
+                    ]);
+                    var server = new Server();
+                    server.addCollection('foos', foos);
+                    server.addCollection('bars', bars);
+                    var expected = [{ id: 1, bar: 'nobody wants me', foos: [] }];
+                    expect(bars.getAll({ embed: ['foos'] })).toEqual(expected);
+                });
+
+                it('should return the object with an array of references for embed many', function() {
+                    var foos = new Collection([
+                        { id: 1, name: 'John', barId: 123 },
+                        { id: 2, name: 'Jane', barId: 456 },
+                        { id: 3, name: 'Jules', barId: 456 }
+                    ]);
+                    var bars = new Collection([
+                        { id: 1, bar: 'nobody wants me' },
+                        { id: 123, bar: 'baz' },
+                        { id: 456, bar: 'bazz' }
+                    ]);
+                    var server = new Server();
+                    server.addCollection('foos', foos);
+                    server.addCollection('bars', bars);
+                    var expected = [
+                        { id: 1, bar: 'nobody wants me', foos: [] },
+                        { id: 123, bar: 'baz', foos: [
+                            { id: 1, name: 'John', barId: 123 }
+                        ] },
+                        { id: 456, bar: 'bazz', foos: [
+                            { id: 2, name: 'Jane', barId: 456 },
+                            { id: 3, name: 'Jules', barId: 456 }
+                        ] }
+                    ];
+                    expect(bars.getAll({ embed: ['foos'] })).toEqual(expected);
+                });
+
+                it('should allow multiple embeds', function() {
+                    var books = new Collection([
+                        { id: 1, title: 'Pride and Prejudice', authorId: 1 },
+                        { id: 2, title: 'Sense and Sensibility', authorId: 1 },
+                        { id: 3, title: 'War and Preace', authorId: 2 }
+                    ]);
+                    var authors = new Collection([
+                        { id: 1, firstName: 'Jane', lastName: 'Austen', countryId: 1 },
+                        { id: 2, firstName: 'Leo', lastName: 'Tosltoi', countryId: 2 }
+                    ]);
+                    var countries = new Collection([
+                        { id: 1, name: 'England' },
+                        { id: 2, name: 'Russia' },
+                    ]);
+                    var server = new Server();
+                    server.addCollection('books', books);
+                    server.addCollection('authors', authors);
+                    server.addCollection('countrys', countries); // nevermind the plural
+                    var expected = [
+                        { id: 1, firstName: 'Jane', lastName: 'Austen', countryId: 1, books: [{ id: 1, title: 'Pride and Prejudice', authorId: 1 }, { id: 2, title: 'Sense and Sensibility', authorId: 1 },], country: { id: 1, name: 'England' } },
+                        { id: 2, firstName: 'Leo', lastName: 'Tosltoi', countryId: 2, books: [{ id: 3, title: 'War and Preace', authorId: 2 }], country: { id: 2, name: 'Russia' } }
+                    ];
+                    expect(authors.getAll({embed: ['books', 'country']})).toEqual(expected);
+                });
+
             });
 
             describe('composite query', function() {


### PR DESCRIPTION
The `embed` param sets the related objects or collections to be embedded in the response.

    // embed author in books
    GET /books?embed=['author']
    HTTP 1.1 200 OK
    Content-Range: items 0-3/4
    Content-Type: application/json
    [
        { id: 0, author_id: 0, title: 'Anna Karenina', author: { id: 0, first_name: 'Leo', last_name: 'Tolstoi' } },
        { id: 1, author_id: 0, title: 'War and Peace', author: { id: 0, first_name: 'Leo', last_name: 'Tolstoi' } },
        { id: 2, author_id: 1, title: 'Pride and Prejudice', author: { id: 1, first_name: 'Jane', last_name: 'Austen' } },
        { id: 3, author_id: 1, title: 'Sense and Sensibility', author: { id: 1, first_name: 'Jane', last_name: 'Austen' } }
    ]

    // embed books in author
    GET /authors?embed=['books']
    HTTP 1.1 200 OK
    Content-Range: items 0-1/2
    Content-Type: application/json
    [
        { id: 0, first_name: 'Leo', last_name: 'Tolstoi', books: [{ id: 0, author_id: 0, title: 'Anna Karenina' }, { id: 1, author_id: 0, title: 'War and Peace' }] },
        { id: 1, first_name: 'Jane', last_name: 'Austen', books: [{ id: 2, author_id: 1, title: 'Pride and Prejudice' }, { id: 3, author_id: 1, title: 'Sense and Sensibility' }] }
    ]

    // you can embed several objects
    GET /authors?embed=['books', 'country']
