### PR TITLE
Support non-integer ids

### DIFF
--- a/src/FetchServer.js
+++ b/src/FetchServer.js
@@ -109,7 +109,7 @@ export default class FetchServer extends Server {
 
                 // handle collections
                 for (let name of this.getCollectionNames()) {
-                    let matches = request.url.match(new RegExp('^' + this.baseUrl + '\\/(' + name + ')(\\/(\\d+))?(\\?.*)?$' ));
+                    let matches = request.url.match(new RegExp('^' + this.baseUrl + '\\/(' + name + ')(\\/(\\w+))?(\\?.*)?$' ));
                     if (!matches) continue;
                     let params = assign({}, this.defaultQuery(name), request.params);
                     if (!matches[2]) {

--- a/src/Server.js
+++ b/src/Server.js
@@ -274,7 +274,7 @@ export default class Server {
 
         // Handle collections
         for (let name of this.getCollectionNames()) {
-            let matches = request.url.match(new RegExp('^' + this.baseUrl + '\\/(' + name + ')(\\/(\\d+))?(\\?.*)?$' ));
+            let matches = request.url.match(new RegExp('^' + this.baseUrl + '\\/(' + name + ')(\\/(\\w+))?(\\?.*)?$' ));
             if (!matches) continue;
             let params = assign({}, this.defaultQuery(name), request.params);
             if (!matches[2]) {


### PR DESCRIPTION
Would be great to support arbitrary string ids.

This simple fix seems to work, but let me know if anything else needs to be done to properly implement this.