### PR TITLE
fetch-example error fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ var data = {
 };
 const restServer = new FakeRest.FetchServer('http://localhost:3000');
 restServer.init(data);
-fetchMock.mock('^http://localhost:3000', restServer.getHandler());
+fetchMock.mock('begin:http://localhost:3000', restServer.getHandler());
 ```
 
 FakeRest will now intercept every XmlHTTPResquest to the REST server. The handled routes for collections of items are:


### PR DESCRIPTION
With the current code the 'fetch' example throws errors. Please compare the docs of fetch-mock on "begin:' at http://www.wheresrhys.co.uk/fetch-mock/#api-mockingmock_matcher