### PR TITLE
[WIP] Refactor adapters

### DIFF
--- a/example/msw.ts
+++ b/example/msw.ts
@@ -1,10 +1,10 @@
 import { setupWorker } from 'msw/browser';
-import { MswServer, withDelay } from '../src';
+import { getMswHandler, withDelay } from '../src';
 import { data } from './data';
 import { dataProvider as defaultDataProvider } from './dataProvider';
 
 export const initializeMsw = async () => {
-    const restServer = new MswServer({
+    const handler = getMswHandler({
         baseUrl: 'http://localhost:3000',
         data,
         middlewares: [
@@ -46,7 +46,7 @@ export const initializeMsw = async () => {
             },
         ],
     });
-    const worker = setupWorker(restServer.getHandler());
+    const worker = setupWorker(handler);
     return worker.start({
         quiet: true, // Instruct MSW to not log requests in the console
         onUnhandledRequest: 'bypass', // Instruct MSW to ignore requests we don't handle

--- a/example/msw.ts
+++ b/example/msw.ts
@@ -3,49 +3,49 @@ import { MswServer, withDelay } from '../src';
 import { data } from './data';
 import { dataProvider as defaultDataProvider } from './dataProvider';
 
-const restServer = new MswServer({
-    baseUrl: 'http://localhost:3000',
-    data,
-});
-
-restServer.addMiddleware(withDelay(300));
-restServer.addMiddleware(async (request, context, next) => {
-    if (!request.headers?.get('Authorization')) {
-        return {
-            status: 401,
-            headers: {},
-        };
-    }
-    return next(request, context);
-});
-
-restServer.addMiddleware(async (request, context, next) => {
-    if (context.collection === 'books' && request.method === 'POST') {
-        if (
-            restServer.database.getCount(context.collection, {
-                filter: {
-                    title: context.requestBody?.title,
-                },
-            }) > 0
-        ) {
-            throw new Response(
-                JSON.stringify({
-                    errors: {
-                        title: 'An article with this title already exists. The title must be unique.',
-                    },
-                }),
-                {
-                    status: 400,
-                    statusText: 'Title is required',
-                },
-            );
-        }
-    }
-
-    return next(request, context);
-});
-
 export const initializeMsw = async () => {
+    const restServer = new MswServer({
+        baseUrl: 'http://localhost:3000',
+        data,
+        middlewares: [
+            withDelay(300),
+            async (context, next) => {
+                if (!context.headers?.get('Authorization')) {
+                    return {
+                        status: 401,
+                        headers: {},
+                    };
+                }
+                return next(context);
+            },
+            async (context, next) => {
+                if (
+                    context.collection === 'books' &&
+                    context.method === 'POST'
+                ) {
+                    if (
+                        data[context.collection].some(
+                            (book) => book.title === context.requestBody?.title,
+                        )
+                    ) {
+                        throw new Response(
+                            JSON.stringify({
+                                errors: {
+                                    title: 'An article with this title already exists. The title must be unique.',
+                                },
+                            }),
+                            {
+                                status: 400,
+                                statusText: 'Title is required',
+                            },
+                        );
+                    }
+                }
+
+                return next(context);
+            },
+        ],
+    });
     const worker = setupWorker(restServer.getHandler());
     return worker.start({
         quiet: true, // Instruct MSW to not log requests in the console

--- a/example/sinon.ts
+++ b/example/sinon.ts
@@ -9,42 +9,19 @@ export const initializeSinon = () => {
         baseUrl: 'http://localhost:3000',
         data,
         loggingEnabled: true,
-    });
-
-    restServer.addMiddleware(withDelay(300));
-    restServer.addMiddleware(async (request, context, next) => {
-        if (request.requestHeaders.Authorization === undefined) {
-            return {
-                status: 401,
-                headers: {},
-            };
-        }
-
-        return next(request, context);
-    });
-
-    restServer.addMiddleware(async (request, context, next) => {
-        if (context.collection === 'books' && request.method === 'POST') {
-            if (
-                restServer.database.getCount(context.collection, {
-                    filter: {
-                        title: context.requestBody?.title,
-                    },
-                }) > 0
-            ) {
-                return {
-                    status: 400,
-                    headers: {},
-                    body: {
-                        errors: {
-                            title: 'An article with this title already exists. The title must be unique.',
-                        },
-                    },
-                };
-            }
-        }
-
-        return next(request, context);
+        middlewares: [
+            withDelay(300),
+            async (context, next) => {
+                if (!context.headers?.get('Authorization')) {
+                    return {
+                        status: 401,
+                        headers: {},
+                    };
+                }
+                return next(context);
+            },
+            // FIXME: add validation middleware
+        ],
     });
 
     // use sinon.js to monkey-patch XmlHttpRequest

--- a/src/BaseServer.ts
+++ b/src/BaseServer.ts
@@ -1,7 +1,12 @@
 import type { Collection } from './Collection.js';
 import { Database, type DatabaseOptions } from './Database.js';
 import type { Single } from './Single.js';
-import type { CollectionItem, QueryFunction } from './types.js';
+import type {
+    BaseResponse,
+    FakeRestContext,
+    CollectionItem,
+    QueryFunction,
+} from './types.js';
 
 export class BaseServer {
     baseUrl = '';
@@ -390,22 +395,6 @@ export type BaseServerOptions = DatabaseOptions & {
     batchUrl?: string | null;
     defaultQuery?: QueryFunction;
     middlewares?: Array<Middleware>;
-};
-
-export type BaseResponse = {
-    status: number;
-    body?: Record<string, any> | Record<string, any>[];
-    headers: { [key: string]: string };
-};
-
-export type FakeRestContext = {
-    url?: string;
-    headers?: Headers;
-    method?: string;
-    collection?: string;
-    single?: string;
-    requestBody: Record<string, any> | undefined;
-    params: { [key: string]: any };
 };
 
 export type NormalizedRequest = Pick<

--- a/src/BaseServer.ts
+++ b/src/BaseServer.ts
@@ -78,7 +78,6 @@ export class BaseServer {
             if (middleware) {
                 return middleware(context, next);
             }
-
             return this.handleRequest(context);
         };
 

--- a/src/BaseServer.ts
+++ b/src/BaseServer.ts
@@ -6,6 +6,7 @@ import type {
     FakeRestContext,
     CollectionItem,
     QueryFunction,
+    NormalizedRequest,
 } from './types.js';
 
 export class BaseServer {
@@ -396,8 +397,3 @@ export type BaseServerOptions = DatabaseOptions & {
     defaultQuery?: QueryFunction;
     middlewares?: Array<Middleware>;
 };
-
-export type NormalizedRequest = Pick<
-    FakeRestContext,
-    'url' | 'method' | 'params' | 'requestBody' | 'headers'
->;

--- a/src/SimpleRestServer.ts
+++ b/src/SimpleRestServer.ts
@@ -9,7 +9,7 @@ import type {
     NormalizedRequest,
 } from './types.js';
 
-export class BaseServer {
+export class SimpleRestServer {
     baseUrl = '';
     defaultQuery: QueryFunction = () => ({});
     middlewares: Array<Middleware>;

--- a/src/adapters/FetchMockServer.ts
+++ b/src/adapters/FetchMockServer.ts
@@ -1,7 +1,7 @@
 import { BaseServer } from '../BaseServer.js';
 import { parseQueryString } from '../parseQueryString.js';
-import type { BaseServerOptions, NormalizedRequest } from '../BaseServer.js';
-import type { BaseResponse, APIServer } from '../types.js';
+import type { BaseServerOptions } from '../BaseServer.js';
+import type { BaseResponse, APIServer, NormalizedRequest } from '../types.js';
 import type { MockResponseObject } from 'fetch-mock';
 
 export class FetchMockServer {

--- a/src/adapters/FetchMockServer.ts
+++ b/src/adapters/FetchMockServer.ts
@@ -1,6 +1,6 @@
-import { BaseServer } from '../BaseServer.js';
+import { SimpleRestServer } from '../SimpleRestServer.js';
 import { parseQueryString } from '../parseQueryString.js';
-import type { BaseServerOptions } from '../BaseServer.js';
+import type { BaseServerOptions } from '../SimpleRestServer.js';
 import type { BaseResponse, APIServer, NormalizedRequest } from '../types.js';
 import type { MockResponseObject } from 'fetch-mock';
 
@@ -13,7 +13,7 @@ export class FetchMockServer {
         server,
         ...options
     }: FetchMockServerOptions = {}) {
-        this.server = server || new BaseServer(options);
+        this.server = server || new SimpleRestServer(options);
         this.loggingEnabled = loggingEnabled;
     }
 

--- a/src/adapters/FetchMockServer.ts
+++ b/src/adapters/FetchMockServer.ts
@@ -1,28 +1,39 @@
-import type { MockResponseObject } from 'fetch-mock';
-import {
-    type BaseResponse,
-    BaseServer,
-    type FakeRestContext,
-    type BaseServerOptions,
-} from '../BaseServer.js';
+import { BaseServer } from '../BaseServer.js';
 import { parseQueryString } from '../parseQueryString.js';
+import type {
+    BaseResponse,
+    FakeRestContext,
+    BaseServerOptions,
+    NormalizedRequest,
+} from '../BaseServer.js';
+import type { MockResponseObject } from 'fetch-mock';
 
-export class FetchMockServer extends BaseServer<Request, MockResponseObject> {
+export class FetchMockServer {
     loggingEnabled = false;
+    server;
 
     constructor({
         loggingEnabled = false,
+        server,
         ...options
     }: FetchMockServerOptions = {}) {
-        super(options);
+        this.server = server || new BaseServer(options);
         this.loggingEnabled = loggingEnabled;
     }
 
-    toggleLogging() {
-        this.loggingEnabled = !this.loggingEnabled;
+    getHandler() {
+        const handler = async (url: string, options: RequestInit) => {
+            const request = new Request(url, options);
+            const normalizedRequest = await this.getNormalizedRequest(request);
+            const response = await this.server.handle(normalizedRequest);
+            this.log(request, response, normalizedRequest);
+            return response as MockResponseObject;
+        };
+
+        return handler;
     }
 
-    async getNormalizedRequest(request: Request) {
+    async getNormalizedRequest(request: Request): Promise<NormalizedRequest> {
         const req =
             typeof request === 'string' ? new Request(request) : request;
         const queryString = req.url
@@ -39,32 +50,28 @@ export class FetchMockServer extends BaseServer<Request, MockResponseObject> {
 
         return {
             url: req.url,
+            headers: req.headers,
             params,
             requestBody,
             method: req.method,
         };
     }
 
-    async respond(
-        response: BaseResponse,
-        request: FetchMockFakeRestRequest,
-        context: FakeRestContext,
-    ) {
-        this.log(request, response, context);
-        return response;
-    }
-
     log(
         request: FetchMockFakeRestRequest,
-        response: MockResponseObject,
-        context: FakeRestContext,
+        response: BaseResponse,
+        normalizedRequest: NormalizedRequest,
     ) {
         if (!this.loggingEnabled) return;
         if (console.group) {
             // Better logging in Chrome
-            console.groupCollapsed(context.method, context.url, '(FakeRest)');
+            console.groupCollapsed(
+                normalizedRequest.method,
+                normalizedRequest.url,
+                '(FakeRest)',
+            );
             console.group('request');
-            console.log(context.method, context.url);
+            console.log(normalizedRequest.method, normalizedRequest.url);
             console.log('headers', request.headers);
             console.log('body   ', request.requestJson);
             console.groupEnd();
@@ -76,8 +83,8 @@ export class FetchMockServer extends BaseServer<Request, MockResponseObject> {
         } else {
             console.log(
                 'FakeRest request ',
-                context.method,
-                context.url,
+                normalizedRequest.method,
+                normalizedRequest.url,
                 'headers',
                 request.headers,
                 'body',
@@ -94,12 +101,8 @@ export class FetchMockServer extends BaseServer<Request, MockResponseObject> {
         }
     }
 
-    getHandler() {
-        const handler = (url: string, options: RequestInit) => {
-            return this.handle(new Request(url, options));
-        };
-
-        return handler;
+    toggleLogging() {
+        this.loggingEnabled = !this.loggingEnabled;
     }
 }
 
@@ -122,5 +125,9 @@ export type FetchMockFakeRestRequest = Partial<Request> & {
 };
 
 export type FetchMockServerOptions = BaseServerOptions & {
+    server?: {
+        getContext: (context: NormalizedRequest) => FakeRestContext;
+        handle: (context: FakeRestContext) => Promise<BaseResponse>;
+    };
     loggingEnabled?: boolean;
 };

--- a/src/adapters/FetchMockServer.ts
+++ b/src/adapters/FetchMockServer.ts
@@ -126,7 +126,6 @@ export type FetchMockFakeRestRequest = Partial<Request> & {
 
 export type FetchMockServerOptions = BaseServerOptions & {
     server?: {
-        getContext: (context: NormalizedRequest) => FakeRestContext;
         handle: (context: FakeRestContext) => Promise<BaseResponse>;
     };
     loggingEnabled?: boolean;

--- a/src/adapters/FetchMockServer.ts
+++ b/src/adapters/FetchMockServer.ts
@@ -1,16 +1,12 @@
 import { BaseServer } from '../BaseServer.js';
 import { parseQueryString } from '../parseQueryString.js';
-import type {
-    BaseResponse,
-    FakeRestContext,
-    BaseServerOptions,
-    NormalizedRequest,
-} from '../BaseServer.js';
+import type { BaseServerOptions, NormalizedRequest } from '../BaseServer.js';
+import type { BaseResponse, APIServer } from '../types.js';
 import type { MockResponseObject } from 'fetch-mock';
 
 export class FetchMockServer {
     loggingEnabled = false;
-    server;
+    server: APIServer;
 
     constructor({
         loggingEnabled = false,
@@ -125,8 +121,6 @@ export type FetchMockFakeRestRequest = Partial<Request> & {
 };
 
 export type FetchMockServerOptions = BaseServerOptions & {
-    server?: {
-        handle: (context: FakeRestContext) => Promise<BaseResponse>;
-    };
+    server?: APIServer;
     loggingEnabled?: boolean;
 };

--- a/src/adapters/MswServer.ts
+++ b/src/adapters/MswServer.ts
@@ -1,7 +1,7 @@
 import { http, HttpResponse } from 'msw';
 import { BaseServer } from '../BaseServer.js';
-import type { BaseServerOptions, NormalizedRequest } from '../BaseServer.js';
-import type { APIServer } from '../types.js';
+import type { BaseServerOptions } from '../BaseServer.js';
+import type { APIServer, NormalizedRequest } from '../types.js';
 
 export class MswServer {
     server: APIServer;

--- a/src/adapters/MswServer.ts
+++ b/src/adapters/MswServer.ts
@@ -1,15 +1,10 @@
 import { http, HttpResponse } from 'msw';
 import { BaseServer } from '../BaseServer.js';
-import type {
-    BaseResponse,
-    FakeRestContext,
-    BaseServerOptions,
-    NormalizedRequest,
-} from '../BaseServer.js';
-import type { DatabaseOptions } from '../Database.js';
+import type { BaseServerOptions, NormalizedRequest } from '../BaseServer.js';
+import type { APIServer } from '../types.js';
 
 export class MswServer {
-    server;
+    server: APIServer;
 
     constructor({ server, ...options }: MswServerOptions) {
         this.server = server || new BaseServer(options);
@@ -56,14 +51,11 @@ export class MswServer {
     }
 }
 
-export const getMswHandler = (options: DatabaseOptions) => {
+export const getMswHandler = (options: MswServerOptions) => {
     const server = new MswServer(options);
     return server.getHandler();
 };
 
 export type MswServerOptions = BaseServerOptions & {
-    server?: {
-        baseUrl?: string;
-        handle: (context: FakeRestContext) => Promise<BaseResponse>;
-    };
+    server?: APIServer;
 };

--- a/src/adapters/MswServer.ts
+++ b/src/adapters/MswServer.ts
@@ -1,13 +1,13 @@
 import { http, HttpResponse } from 'msw';
-import { BaseServer } from '../BaseServer.js';
-import type { BaseServerOptions } from '../BaseServer.js';
+import { SimpleRestServer } from '../SimpleRestServer.js';
+import type { BaseServerOptions } from '../SimpleRestServer.js';
 import type { APIServer, NormalizedRequest } from '../types.js';
 
 export class MswServer {
     server: APIServer;
 
     constructor({ server, ...options }: MswServerOptions) {
-        this.server = server || new BaseServer(options);
+        this.server = server || new SimpleRestServer(options);
     }
 
     getHandler() {

--- a/src/adapters/SinonServer.spec.ts
+++ b/src/adapters/SinonServer.spec.ts
@@ -3,7 +3,7 @@ import sinon, { type SinonFakeXMLHttpRequest } from 'sinon';
 import { SinonServer } from './SinonServer.js';
 import { Single } from '../Single.js';
 import { Collection } from '../Collection.js';
-import type { BaseResponse } from '../BaseServer.js';
+import type { BaseResponse } from '../SimpleRestServer.js';
 
 function getFakeXMLHTTPRequest(
     method: string,

--- a/src/adapters/SinonServer.ts
+++ b/src/adapters/SinonServer.ts
@@ -1,5 +1,8 @@
 import type { SinonFakeXMLHttpRequest } from 'sinon';
-import { BaseServer, type BaseServerOptions } from '../BaseServer.js';
+import {
+    SimpleRestServer,
+    type BaseServerOptions,
+} from '../SimpleRestServer.js';
 import { parseQueryString } from '../parseQueryString.js';
 import type { BaseResponse, APIServer, NormalizedRequest } from '../types.js';
 
@@ -12,7 +15,7 @@ export class SinonServer {
         server,
         ...options
     }: SinonServerOptions = {}) {
-        this.server = server || new BaseServer(options);
+        this.server = server || new SimpleRestServer(options);
         this.loggingEnabled = loggingEnabled;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,13 +10,13 @@ import {
 } from './adapters/FetchMockServer.js';
 import { getMswHandler, MswServer } from './adapters/MswServer.js';
 import { Database } from './Database.js';
-import { BaseServer } from './BaseServer.js';
+import { SimpleRestServer } from './SimpleRestServer.js';
 import { Collection } from './Collection.js';
 import { Single } from './Single.js';
 import { withDelay } from './withDelay.js';
 
 export {
-    BaseServer,
+    SimpleRestServer,
     Database,
     getSinonHandler,
     getFetchMockHandler,
@@ -32,7 +32,7 @@ export {
 };
 
 export default {
-    BaseServer,
+    SimpleRestServer,
     Database,
     getSinonHandler,
     getFetchMockHandler,

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,3 +31,24 @@ export type Predicate = <T extends CollectionItem = CollectionItem>(
 ) => boolean;
 
 export type Embed = string | string[];
+
+export type BaseResponse = {
+    status: number;
+    body?: Record<string, any> | Record<string, any>[];
+    headers: { [key: string]: string };
+};
+
+export type FakeRestContext = {
+    url?: string;
+    headers?: Headers;
+    method?: string;
+    collection?: string;
+    single?: string;
+    requestBody: Record<string, any> | undefined;
+    params: { [key: string]: any };
+};
+
+export type APIServer = {
+    baseUrl?: string;
+    handle: (context: FakeRestContext) => Promise<BaseResponse>;
+};

--- a/src/types.ts
+++ b/src/types.ts
@@ -48,6 +48,11 @@ export type FakeRestContext = {
     params: { [key: string]: any };
 };
 
+export type NormalizedRequest = Pick<
+    FakeRestContext,
+    'url' | 'method' | 'params' | 'requestBody' | 'headers'
+>;
+
 export type APIServer = {
     baseUrl?: string;
     handle: (context: FakeRestContext) => Promise<BaseResponse>;

--- a/src/withDelay.ts
+++ b/src/withDelay.ts
@@ -1,4 +1,4 @@
-import type { Middleware } from './BaseServer.js';
+import type { Middleware } from './SimpleRestServer.js';
 
 export const withDelay =
     (delayMs: number): Middleware =>

--- a/src/withDelay.ts
+++ b/src/withDelay.ts
@@ -1,11 +1,11 @@
 import type { Middleware } from './BaseServer.js';
 
 export const withDelay =
-    <RequestType>(delayMs: number): Middleware<RequestType> =>
-    (request, context, next) => {
+    (delayMs: number): Middleware =>
+    (context, next) => {
         return new Promise((resolve) => {
             setTimeout(() => {
-                resolve(next(request, context));
+                resolve(next(context));
             }, delayMs);
         });
     };


### PR DESCRIPTION
## Problem

To reuse the adapters with a different REST dialect, developers must rewrite everything.

## Solution

Use dependency injection instead of inheritance for server logic.

## TODO

- [x] Make BaseServer work only with a context
- [x] Update FetchMockServer to delegate handling to server
- [x] Update MswServer to delegate handling to server
- [x] Update SinonServer to delegate handling to server
- [x] Rename BaseServer to SimpleRestServer
- [ ] Fix validation middleware in Msw and Sinon
- [ ] Fix tests
- [ ] Update doc & upgrade guide

