### PR TITLE
Fix Collection.update() may erase values

### DIFF
--- a/src/Collection.spec.ts
+++ b/src/Collection.spec.ts
@@ -989,6 +989,18 @@ describe('Collection', () => {
             expect(collection.getOne(0)).toEqual({ id: 0, name: 'bar' });
             expect(collection.getOne(1)).toEqual({ id: 1, name: 'baz' });
         });
+
+        it('should not erase fields when the changeset contains undefined values', () => {
+            const collection = new Collection<CollectionItem>({
+                items: [{ id: 0, name: 'foo', title: 'bar' }],
+            });
+            collection.updateOne(0, { name: 'FOO', title: undefined });
+            expect(collection.getOne(0)).toEqual({
+                id: 0,
+                name: 'FOO',
+                title: 'bar',
+            });
+        });
     });
 
     describe('removeOne', () => {


### PR DESCRIPTION
## Problem

Calling `Collection.update()` with an object containing `undefined` values erases the existing value.

```jsx
// will erase the title
collection.updateOne(0, { name: 'FOO', title: undefined });
```

This does not mimic true REST APIs because, when the change payload is serialized to be passed to the network, undefined values are removed.

The erasure is unexpected.

## Solution

Better mimic REST APIs by serializing / unserializing the changes before applying them.