### PR TITLE
Fix Collection and Single should not mutate the provided data

### DIFF
--- a/src/Collection.spec.ts
+++ b/src/Collection.spec.ts
@@ -989,6 +989,18 @@ describe('Collection', () => {
             expect(collection.getOne(0)).toEqual({ id: 0, name: 'bar' });
             expect(collection.getOne(1)).toEqual({ id: 1, name: 'baz' });
         });
+
+        it('should update the original item', () => {
+            const items = [{ name: 'foo' }, { name: 'baz' }];
+            const collection = new Collection<CollectionItem>({
+                items,
+            });
+            collection.updateOne(0, { id: 0, name: 'bar' });
+            expect(collection.getOne(0)).toEqual({ id: 0, name: 'bar' });
+            expect(collection.getOne(1)).toEqual({ id: 1, name: 'baz' });
+            expect(items[0]).toEqual({ name: 'foo' });
+            expect(items[1]).toEqual({ name: 'baz' });
+        });
     });
 
     describe('removeOne', () => {

--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -1,5 +1,6 @@
 import get from 'lodash/get.js';
 import matches from 'lodash/matches.js';
+import cloneDeep from 'lodash/cloneDeep.js';
 import type { Database } from './Database.ts';
 import type {
     CollectionItem,
@@ -196,7 +197,8 @@ export class Collection<T extends CollectionItem = CollectionItem> {
     }
 
     addOne(item: T) {
-        const identifier = item[this.identifierName];
+        const clone = cloneDeep(item);
+        const identifier = clone[this.identifierName];
         if (identifier != null) {
             if (this.getIndex(identifier) !== -1) {
                 throw new Error(
@@ -208,10 +210,10 @@ export class Collection<T extends CollectionItem = CollectionItem> {
             }
         } else {
             // @ts-expect-error - For some reason, TS does not accept writing a generic types with the index signature
-            item[this.identifierName] = this.getNewId();
+            clone[this.identifierName] = this.getNewId();
         }
-        this.items.push(item);
-        return Object.assign({}, item); // clone item to avoid returning the original;
+        this.items.push(clone);
+        return clone; // clone item to avoid returning the original;
     }
 
     updateOne(identifier: number | string, item: T) {

--- a/src/Single.spec.ts
+++ b/src/Single.spec.ts
@@ -144,5 +144,13 @@ describe('Single', () => {
             single.updateOnly({ name: 'bar' });
             expect(single.getOnly()).toEqual({ name: 'bar' });
         });
+
+        it('should not update the original item', () => {
+            const data = { name: 'foo' };
+            const single = new Single(data);
+            single.updateOnly({ name: 'bar' });
+            expect(single.getOnly()).toEqual({ name: 'bar' });
+            expect(data).toEqual({ name: 'foo' });
+        });
     });
 });

--- a/src/Single.ts
+++ b/src/Single.ts
@@ -1,3 +1,4 @@
+import cloneDeep from 'lodash/cloneDeep.js';
 import type { Database } from './Database.ts';
 import type { CollectionItem, Embed, Query } from './types.ts';
 
@@ -12,7 +13,7 @@ export class Single<T extends CollectionItem = CollectionItem> {
                 "Can't initialize a Single with anything except an object",
             );
         }
-        this.obj = obj;
+        this.obj = cloneDeep(obj);
     }
 
     /**


### PR DESCRIPTION
## Problem

`Collection` and `Single` mutate the originally provided data. This is an issue especially in tests.

## Solution 

Always clone the provided data