### PR TITLE
Fix filter null value does not work

### DIFF
--- a/src/Collection.spec.ts
+++ b/src/Collection.spec.ts
@@ -235,6 +235,20 @@ describe('Collection', () => {
                 );
             });
 
+            it('should filter null values properly', () => {
+                const collection = new Collection({
+                    items: [
+                        { name: 'a', is: null },
+                        { name: 'b', is: false },
+                        { name: 'c', is: true },
+                    ],
+                });
+                const expectedNull = [{ name: 'a', id: 0, is: null }];
+                expect(collection.getAll({ filter: { is: null } })).toEqual(
+                    expectedNull,
+                );
+            });
+
             it('should filter array values properly', () => {
                 const collection = new Collection({
                     items: [

--- a/src/Collection.ts
+++ b/src/Collection.ts
@@ -411,6 +411,12 @@ const getSimpleFilter = (key: string, value: any) => {
         };
     }
 
+    if (value == null) {
+        // null or undefined filter
+        return <T extends CollectionItem = CollectionItem>(item: T) =>
+            get(item, key) == null;
+    }
+
     if (typeof value === 'object') {
         return <T extends CollectionItem = CollectionItem>(item: T) =>
             matches(value)(get(item, key));


### PR DESCRIPTION
## Problem

Filter by null values doesn't work. It returns all values.

```js
collection.getAll({ filter: { foo: null } })
```

## Analysis

The current code checks whether the filter value is of type object, which is the case for null, so the null comparison never occurs.

## Solution

Add a specific case for null values.