### PR TITLE
Add ability to sort and filter by relationship

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,11 @@ The `filter` param must be a serialized object literal describing the criteria t
     // when the filter object contains more than one property, the criteria combine with an AND logic
     GET /books?filter={"published_at_gte":"2015-06-12","published_at_lte":"2015-06-15"} // return books published between two dates
 
+You can also filter by relationship fields when using embed:
+
+    GET /books?embed=["author"]&filter={"author.name":"Leo Tolstoi"} // return books by Leo Tolstoi
+    GET /books?embed=["author"]&filter={"author.age_gte":50} // return books by authors aged 50 or more
+
 The `sort` param must be a serialized array literal defining first the property used for sorting, then the sorting direction.
 
     GET /author?sort=["date_of_birth","asc"]  // return authors, the oldest first

--- a/README.md
+++ b/README.md
@@ -221,6 +221,11 @@ The `sort` param must be a serialized array literal defining first the property 
     GET /author?sort=["date_of_birth","asc"]  // return authors, the oldest first
     GET /author?sort=["date_of_birth","desc"]  // return authors, the youngest first
 
+You can also sort by relationship fields when using embed:
+
+    GET /books?embed=["author"]&sort=["author.name","asc"]  // return books sorted by author name
+    GET /books?embed=["author"]&sort=["author.name","desc"] // return books sorted by author name in reverse order
+
 The `range` param defines the number of results by specifying the rank of the first and last results. The first result is #0.
 
     GET /books?range=[0-9] // return the first 10 books

--- a/src/Collection.spec.ts
+++ b/src/Collection.spec.ts
@@ -284,6 +284,154 @@ describe('Collection', () => {
                 ).toEqual(expected);
             });
 
+            it('should filter by relationship field', () => {
+                const books = new Collection({
+                    items: [
+                        { title: 'Pride and Prejudice', author_id: 1 },
+                        { title: 'War and Peace', author_id: 0 },
+                        { title: 'Anna Karenina', author_id: 0 },
+                        { title: 'Sense and Sensibility', author_id: 1 },
+                    ],
+                });
+                const authors = new Collection({
+                    items: [
+                        { id: 0, name: 'Leo Tolstoi' },
+                        { id: 1, name: 'Jane Austen' },
+                    ],
+                });
+                const database = new Database();
+                database.addCollection('books', books);
+                database.addCollection('authors', authors);
+
+                const result = books.getAll({
+                    embed: ['author'],
+                    filter: { 'author.name': 'Leo Tolstoi' },
+                }) as any[];
+
+                expect(result.length).toEqual(2);
+                expect(result[0].title).toEqual('War and Peace');
+                expect(result[1].title).toEqual('Anna Karenina');
+                expect(result[0].author.name).toEqual('Leo Tolstoi');
+                expect(result[1].author.name).toEqual('Leo Tolstoi');
+            });
+
+            it('should filter by relationship field with multiple filters', () => {
+                const books = new Collection({
+                    items: [
+                        {
+                            title: 'Pride and Prejudice',
+                            author_id: 1,
+                            published: 1813,
+                        },
+                        {
+                            title: 'War and Peace',
+                            author_id: 0,
+                            published: 1869,
+                        },
+                        {
+                            title: 'Anna Karenina',
+                            author_id: 0,
+                            published: 1877,
+                        },
+                        {
+                            title: 'Sense and Sensibility',
+                            author_id: 1,
+                            published: 1811,
+                        },
+                    ],
+                });
+                const authors = new Collection({
+                    items: [
+                        { id: 0, name: 'Leo Tolstoi' },
+                        { id: 1, name: 'Jane Austen' },
+                    ],
+                });
+                const database = new Database();
+                database.addCollection('books', books);
+                database.addCollection('authors', authors);
+
+                const result = books.getAll({
+                    embed: ['author'],
+                    filter: {
+                        'author.name': 'Jane Austen',
+                        published_gte: 1813,
+                    },
+                }) as any[];
+
+                expect(result.length).toEqual(1);
+                expect(result[0].title).toEqual('Pride and Prejudice');
+                expect(result[0].author.name).toEqual('Jane Austen');
+            });
+
+            it('should filter by relationship field with operators', () => {
+                const books = new Collection({
+                    items: [
+                        { title: 'Book A', author_id: 0 },
+                        { title: 'Book B', author_id: 1 },
+                        { title: 'Book C', author_id: 2 },
+                        { title: 'Book D', author_id: 3 },
+                    ],
+                });
+                const authors = new Collection({
+                    items: [
+                        { id: 0, name: 'Author A', age: 30 },
+                        { id: 1, name: 'Author B', age: 40 },
+                        { id: 2, name: 'Author C', age: 50 },
+                        { id: 3, name: 'Author D', age: 60 },
+                    ],
+                });
+                const database = new Database();
+                database.addCollection('books', books);
+                database.addCollection('authors', authors);
+
+                const result = books.getAll({
+                    embed: ['author'],
+                    filter: { 'author.age_gte': 50 },
+                }) as any[];
+
+                expect(result.length).toEqual(2);
+                expect(result[0].title).toEqual('Book C');
+                expect(result[1].title).toEqual('Book D');
+                expect(result[0].author.age).toEqual(50);
+                expect(result[1].author.age).toEqual(60);
+            });
+
+            it('should filter and sort by relationship fields together', () => {
+                const books = new Collection({
+                    items: [
+                        { title: 'Book 1', author_id: 0, year: 2020 },
+                        { title: 'Book 2', author_id: 1, year: 2021 },
+                        { title: 'Book 3', author_id: 2, year: 2019 },
+                        { title: 'Book 4', author_id: 3, year: 2022 },
+                        { title: 'Book 5', author_id: 1, year: 2023 },
+                    ],
+                });
+                const authors = new Collection({
+                    items: [
+                        { id: 0, name: 'Zoe', country: 'USA' },
+                        { id: 1, name: 'Alice', country: 'UK' },
+                        { id: 2, name: 'Bob', country: 'USA' },
+                        { id: 3, name: 'Charlie', country: 'Canada' },
+                    ],
+                });
+                const database = new Database();
+                database.addCollection('books', books);
+                database.addCollection('authors', authors);
+
+                // Filter by author country and sort by author name
+                const result = books.getAll({
+                    embed: ['author'],
+                    filter: { 'author.country': 'USA' },
+                    sort: ['author.name', 'asc'],
+                }) as any[];
+
+                expect(result.length).toEqual(2);
+                expect(result[0].author.name).toEqual('Bob');
+                expect(result[1].author.name).toEqual('Zoe');
+                expect(result[0].title).toEqual('Book 3');
+                expect(result[1].title).toEqual('Book 1');
+            });
+
             it('should filter values with objects', () => {
                 const collection = new Collection({
                     items: [

--- a/src/Collection.spec.ts
+++ b/src/Collection.spec.ts
@@ -76,6 +76,96 @@ describe('Collection', () => {
                 }).toThrow(new Error('Unsupported sort type'));
             });
 
+            it('should sort by nested relationship field', () => {
+                const books = new Collection({
+                    items: [
+                        { title: 'Pride and Prejudice', author_id: 1 },
+                        { title: 'War and Peace', author_id: 0 },
+                        { title: 'Anna Karenina', author_id: 0 },
+                        { title: 'Sense and Sensibility', author_id: 1 },
+                    ],
+                });
+                const authors = new Collection({
+                    items: [
+                        { id: 0, name: 'Leo Tolstoi' },
+                        { id: 1, name: 'Jane Austen' },
+                    ],
+                });
+                const database = new Database();
+                database.addCollection('books', books);
+                database.addCollection('authors', authors);
+
+                const result = books.getAll({
+                    embed: ['author'],
+                    sort: ['author.name', 'asc'],
+                }) as any[];
+
+                expect(result[0].author.name).toEqual('Jane Austen');
+                expect(result[1].author.name).toEqual('Jane Austen');
+                expect(result[2].author.name).toEqual('Leo Tolstoi');
+                expect(result[3].author.name).toEqual('Leo Tolstoi');
+            });
+
+            it('should sort by nested relationship field in descending order', () => {
+                const books = new Collection({
+                    items: [
+                        { title: 'Pride and Prejudice', author_id: 1 },
+                        { title: 'War and Peace', author_id: 0 },
+                        { title: 'Anna Karenina', author_id: 0 },
+                        { title: 'Sense and Sensibility', author_id: 1 },
+                    ],
+                });
+                const authors = new Collection({
+                    items: [
+                        { id: 0, name: 'Leo Tolstoi' },
+                        { id: 1, name: 'Jane Austen' },
+                    ],
+                });
+                const database = new Database();
+                database.addCollection('books', books);
+                database.addCollection('authors', authors);
+
+                const result = books.getAll({
+                    embed: ['author'],
+                    sort: ['author.name', 'desc'],
+                }) as any[];
+
+                expect(result[0].author.name).toEqual('Leo Tolstoi');
+                expect(result[1].author.name).toEqual('Leo Tolstoi');
+                expect(result[2].author.name).toEqual('Jane Austen');
+                expect(result[3].author.name).toEqual('Jane Austen');
+            });
+
+            it('should sort by nested relationship field with string sort', () => {
+                const books = new Collection({
+                    items: [
+                        { title: 'Book 1', author_id: 0 },
+                        { title: 'Book 2', author_id: 1 },
+                        { title: 'Book 3', author_id: 2 },
+                    ],
+                });
+                const authors = new Collection({
+                    items: [
+                        { id: 0, name: 'Author C', country: 'USA' },
+                        { id: 1, name: 'Author A', country: 'England' },
+                        { id: 2, name: 'Author B', country: 'France' },
+                    ],
+                });
+                const database = new Database();
+                database.addCollection('books', books);
+                database.addCollection('authors', authors);
+
+                // Get books with embedded authors and sort by author.country
+                const result = books.getAll({
+                    embed: ['author'],
+                    sort: 'author.country',
+                }) as any[];
+
+                expect(result[0].author.country).toEqual('England');
+                expect(result[1].author.country).toEqual('France');
+                expect(result[2].author.country).toEqual('USA');
+            });
+
             it('should sort by sort function', () => {
                 const collection = new Collection({
                     items: [{ name: 'c' }, { name: 'a' }, { name: 'b' }],


### PR DESCRIPTION
You can now filter by relationship fields when using embed:

    GET /books?embed=["author"]&filter={"author.name":"Leo Tolstoi"} // return books by Leo Tolstoi
    GET /books?embed=["author"]&filter={"author.age_gte":50} // return books by authors aged 50 or more

You can also sort by relationship fields when using embed:

    GET /books?embed=["author"]&sort=["author.name","asc"]  // return books sorted by author name
    GET /books?embed=["author"]&sort=["author.name","desc"] // return books sorted by author name in reverse order